### PR TITLE
Fix - Correct Typescript Constructor Signature Typings To Match JS Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-category",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A wrapper around Bunyan that provides support for log categorization and category-based configuration",
   "repository": {
     "type": "git",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 import Logger, * as bunyan from "bunyan";
 
 declare class CategoryLogger extends Logger {
-  constructor(options: CategoryLogger.CategoryLoggerOptions);
+  constructor(options: CategoryLogger.CategoryLoggerOptions, _childOptions?: Record<string, any>);
 
   static createLogger(
     options: CategoryLogger.CategoryLoggerOptions

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 import Logger, * as bunyan from "bunyan";
 
 declare class CategoryLogger extends Logger {
-  constructor(options: CategoryLogger.CategoryLoggerOptions, _childOptions?: Record<string, any>);
+  constructor(options: CategoryLogger.CategoryLoggerOptions, _childOptions?: Record<string, string|number|Object>);
 
   static createLogger(
     options: CategoryLogger.CategoryLoggerOptions


### PR DESCRIPTION
Ensure typescript constructor typings for CategoryLogger class match actual js class, so CategoryLogger class can be extended in Typescript extension logger class in platform-sdk-logging